### PR TITLE
Reintroduced forEach method to markup renderer

### DIFF
--- a/lib/renderMarkup.js
+++ b/lib/renderMarkup.js
@@ -30,6 +30,10 @@ const enabledTags = [
 let usedTags = new Set()
 let cssRules = []
 
+function forEach (context, callback) {
+  return [].forEach.call(context, callback)
+}
+
 function map (context, callback) {
   return [].map.call(context, callback)
 }


### PR DESCRIPTION
This method was absent and causing unhandled promise rejections on --react-native and --camelCase.